### PR TITLE
Feature add argument protocol

### DIFF
--- a/elastic.go
+++ b/elastic.go
@@ -139,6 +139,7 @@ type ElasticIndicesStatsIndex struct {
 
 func getClusterHealth(
 	elasticDSN string,
+	protocol string,
 	elasticsearchAuthToken string,
 ) (*ElasticClusterHealth, error) {
 
@@ -146,7 +147,7 @@ func getClusterHealth(
 
 	var elasticClusterHealth ElasticClusterHealth
 
-	clutserHealthURL := fmt.Sprintf("http://%s/_cluster/health", elasticDSN)
+	clutserHealthURL := fmt.Sprintf("%s://%s/_cluster/health", protocol, elasticDSN)
 	request, err := http.NewRequest("GET", clutserHealthURL, nil)
 	if err != nil {
 		return nil, hierr.Errorf(
@@ -193,6 +194,7 @@ func getClusterHealth(
 
 func getNodeStats(
 	elasticDSN string,
+	protocol string,
 	elasticsearchAuthToken string,
 ) (*ElasticNodesStats, error) {
 
@@ -200,7 +202,7 @@ func getNodeStats(
 
 	var elasticNodesStats ElasticNodesStats
 
-	nodeStatsURL := fmt.Sprintf("http://%s/_nodes/_local/stats", elasticDSN)
+	nodeStatsURL := fmt.Sprintf("%s://%s/_nodes/_local/stats", protocol, elasticDSN)
 	request, err := http.NewRequest("GET", nodeStatsURL, nil)
 	if err != nil {
 		return nil, hierr.Errorf(
@@ -247,6 +249,7 @@ func getNodeStats(
 
 func getIndicesStats(
 	elasticDSN string,
+	protocol string,
 	elasticsearchAuthToken string,
 ) (*ElasticIndicesStats, error) {
 
@@ -254,7 +257,7 @@ func getIndicesStats(
 
 	var elasticIndicesStats ElasticIndicesStats
 
-	indicesStatsURL := fmt.Sprintf("http://%s/_stats", elasticDSN)
+	indicesStatsURL := fmt.Sprintf("%s://%s/_stats", protocol, elasticDSN)
 	request, err := http.NewRequest("GET", indicesStatsURL, nil)
 	if err != nil {
 		return nil, hierr.Errorf(

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ Options:
   -e --elasticsearch <dsn>      DSN of Elasticsearch server
                                   [default: 127.0.0.1:9200].
   --protocol=<http|https>       Protocol used to access your elasticsearch cluster
-  				  [default: http].
+                                  [default: http].
   --agg-group <group>           Group name which will be use for aggregate
                                   item values [default: None].
   -u --user <name>              User for authenticate through 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -31,6 +32,8 @@ Options:
                                   or indices [default: global].
   -e --elasticsearch <dsn>      DSN of Elasticsearch server
                                   [default: 127.0.0.1:9200].
+  --protocol <http|https>	Protocol used to access your elasticsearch cluster
+  				  [default: http].
   --agg-group <group>           Group name which will be use for aggregate
                                   item values [default: None].
   -u --user <name>              User for authenticate through 
@@ -58,6 +61,17 @@ Misc options:
 	args, _ := docopt.Parse(usage, nil, true, version, false)
 
 	elasticDSN := args["--elasticsearch"].(string)
+
+	protocol := strings.ToLower(args["--protocol"].(string))
+	if protocol != "" {
+		var re = regexp.MustCompile(`(http|https)`)
+		if !re.MatchString(protocol) {
+			fmt.Println("Protocol can be either 'http' or 'https'")
+			os.Exit(1)
+		}
+	} else {
+		protocol = "http"
+	}
 
 	aggGroup := args["--agg-group"].(string)
 
@@ -114,6 +128,7 @@ Misc options:
 
 		indicesStats, err := getIndicesStats(
 			elasticDSN,
+			protocol,
 			elasticsearchAuthToken,
 		)
 		if err != nil {
@@ -140,6 +155,7 @@ Misc options:
 	case "global":
 		clusterHealth, err := getClusterHealth(
 			elasticDSN,
+			protocol,
 			elasticsearchAuthToken,
 		)
 		if err != nil {
@@ -149,6 +165,7 @@ Misc options:
 
 		nodesStats, err := getNodeStats(
 			elasticDSN,
+			protocol,
 			elasticsearchAuthToken,
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ Options:
                                   or indices [default: global].
   -e --elasticsearch <dsn>      DSN of Elasticsearch server
                                   [default: 127.0.0.1:9200].
-  --protocol <http|https>	Protocol used to access your elasticsearch cluster
+  --protocol=<http|https>	Protocol used to access your elasticsearch cluster
   				  [default: http].
   --agg-group <group>           Group name which will be use for aggregate
                                   item values [default: None].
@@ -69,8 +69,6 @@ Misc options:
 			fmt.Println("Protocol can be either 'http' or 'https'")
 			os.Exit(1)
 		}
-	} else {
-		protocol = "http"
 	}
 
 	aggGroup := args["--agg-group"].(string)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ Options:
                                   or indices [default: global].
   -e --elasticsearch <dsn>      DSN of Elasticsearch server
                                   [default: 127.0.0.1:9200].
-  --protocol=<http|https>	Protocol used to access your elasticsearch cluster
+  --protocol=<http|https>       Protocol used to access your elasticsearch cluster
   				  [default: http].
   --agg-group <group>           Group name which will be use for aggregate
                                   item values [default: None].


### PR DESCRIPTION
Hi,

This pull request add a new argument « protocol » to make it possible to interact with the ES cluster through http or https.

This new argument is optional and http remain the default value, so there is no need to change anything on the agent conf file « zabbix-agent-extension-elasticsearch.conf ».

Example of the edited file with the protocol argument :
> UserParameter=elasticsearch.discovery[*], /etc/zabbix/externalscripts/zabbix-agent-extension-elasticsearch --discovery --proto https --elasticsearch $1 --agg-group $2 --user $3 --password $4