### PR TITLE
Feature set zabbix hostname as a macro

### DIFF
--- a/template_elasticsearch_service.xml
+++ b/template_elasticsearch_service.xml
@@ -717,7 +717,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>elasticsearch.indices.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH}]</key>
+                    <key>elasticsearch.indices.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH},{$ZABBIX_HOSTNAME}]</key>
                     <delay>60</delay>
                     <history>90d</history>
                     <trends>0</trends>
@@ -2299,7 +2299,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>elasticsearch.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$ES_USER},{$ES_PASSWORD},{$CA_PATH}]</key>
+                    <key>elasticsearch.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$ES_USER},{$ES_PASSWORD},{$CA_PATH},{$ZABBIX_HOSTNAME}]</key>
                     <delay>30</delay>
                     <history>90d</history>
                     <trends>0</trends>
@@ -2465,7 +2465,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>elasticsearch.discovery[{$ES_ADDRESS},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH}]</key>
+                    <key>elasticsearch.discovery[{$ES_ADDRESS},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH},{$ZABBIX_HOSTNAME}]</key>
                     <delay>5m</delay>
                     <status>0</status>
                     <allowed_hosts/>
@@ -3460,7 +3460,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>elasticsearch.indices.discovery[{$ES_ADDRESS},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH}]</key>
+                    <key>elasticsearch.indices.discovery[{$ES_ADDRESS},{$GROUPNAME},{$ES_USER},{$ES_PASSWORD},{$CA_PATH},{$ZABBIX_HOSTNAME}]</key>
                     <delay>5m</delay>
                     <status>0</status>
                     <allowed_hosts/>
@@ -3780,6 +3780,10 @@
                     <macro>{$GROUPNAME}</macro>
                     <value>None</value>
                 </macro>
+                <macro>
+                    <macro>{$ZABBIX_HOSTNAME}</macro>
+                    <value>None</value>
+                </macro>
             </macros>
             <templates/>
             <screens/>
@@ -3787,7 +3791,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template App Elasticsearch Service:elasticsearch.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$ES_USER},{$ES_PASSWORD},{$CA_PATH}].regexp(&quot;^OK&quot;)}=0</expression>
+            <expression>{Template App Elasticsearch Service:elasticsearch.stats[{$ZABBIX_SERVER_IP},{$ES_ADDRESS},{$ES_ZBX_PREFIX},{$ES_USER},{$ES_PASSWORD},{$CA_PATH},{$ZABBIX_HOSTNAME}].regexp(&quot;^OK&quot;)}=0</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Elasticsearch cannot get stats</name>

--- a/zabbix-agent-extension-elasticsearch.conf
+++ b/zabbix-agent-extension-elasticsearch.conf
@@ -1,5 +1,5 @@
-UserParameter=elasticsearch.discovery[*], /usr/bin/zabbix-agent-extension-elasticsearch --discovery --elasticsearch $1 --agg-group $2 --user $3 --password $4 --ca $5
-UserParameter=elasticsearch.stats[*], /usr/bin/zabbix-agent-extension-elasticsearch --zabbix $1 --elasticsearch $2 --prefix $3 --user $4 --password $5 --ca $6
+UserParameter=elasticsearch.discovery[*], /usr/bin/zabbix-agent-extension-elasticsearch --discovery --elasticsearch $1 --agg-group $2 --user $3 --password $4 --ca $5 --hostname $6
+UserParameter=elasticsearch.stats[*], /usr/bin/zabbix-agent-extension-elasticsearch --zabbix $1 --elasticsearch $2 --prefix $3 --user $4 --password $5 --ca $6 --hostname $7
 #
-UserParameter=elasticsearch.indices.discovery[*], /usr/bin/zabbix-agent-extension-elasticsearch --type indices --discovery --elasticsearch $1 --agg-group $2 --user $3 --password $4 --ca $5
-UserParameter=elasticsearch.indices.stats[*], /usr/bin/zabbix-agent-extension-elasticsearch --type indices --zabbix $1 --elasticsearch $2 --prefix $3 --agg-group $4 --user $5 --password $6 --ca $7
+UserParameter=elasticsearch.indices.discovery[*], /usr/bin/zabbix-agent-extension-elasticsearch --type indices --discovery --elasticsearch $1 --agg-group $2 --user $3 --password $4 --ca $5 --hostname $6
+UserParameter=elasticsearch.indices.stats[*], /usr/bin/zabbix-agent-extension-elasticsearch --type indices --zabbix $1 --elasticsearch $2 --prefix $3 --agg-group $4 --user $5 --password $6 --ca $7 --hostname $8


### PR DESCRIPTION
Hi,

The current implementation of the « hostname » argument required by the program to send data to the zabbix server is a little bit poor. Indeed, there is no mechanism to dynamically set it by reading the _zabbix_agentd.conf_ file on the server as described in the [official documentation](https://www.zabbix.com/documentation/4.2/manual/appendix/config/zabbix_agentd).

Expl on my system:
```
$ grep Hostname= /etc/zabbix/zabbix_agentd.conf
Hostname=my_hostname
```

I propose to set it with the use of a zabbix macro directly on the zabbix host. As the current default value of the « hostname » argument is « None », this PR doesn't change much to the usage.

If in the future, the dynamic reading of this parameter is implemented, the changes of this PR could be discarded.