### PR TITLE
Add nodes stats get metrics

### DIFF
--- a/indices.go
+++ b/indices.go
@@ -174,6 +174,13 @@ func createNodeStatsIndices(
 		prefix,
 	)
 
+	metrics = createNodeStatsIndicesGet(
+		hostname,
+		&nodeStats,
+		metrics,
+		prefix,
+	)
+
 	return metrics
 }
 
@@ -693,6 +700,40 @@ func createNodeStatsIndicesQueryCache(
 				"node_stats.indices.query_cache.evictions",
 			),
 			strconv.Itoa(int(nodeStats.Indices.QueryCache.Evictions)),
+		),
+	)
+
+	return metrics
+}
+
+func createNodeStatsIndicesGet(
+	hostname string,
+	nodeStats *ElasticNodeStats,
+	metrics []*zsend.Metric,
+	prefix string,
+) []*zsend.Metric {
+
+	metrics = append(
+		metrics,
+		zsend.NewMetric(
+			hostname,
+			makePrefix(
+				prefix,
+				"node_stats.indices.get.missing_total",
+			),
+			strconv.Itoa(int(nodeStats.Indices.Get.MissingTotal)),
+		),
+	)
+
+	metrics = append(
+		metrics,
+		zsend.NewMetric(
+			hostname,
+			makePrefix(
+				prefix,
+				"node_stats.indices.get.missing_time_in_millis",
+			),
+			strconv.Itoa(int(nodeStats.Indices.Get.MissingTimeInMillis)),
 		),
 	)
 

--- a/template_elasticsearch_service.xml
+++ b/template_elasticsearch_service.xml
@@ -1445,6 +1445,88 @@
                     <master_item/>
                 </item>
                 <item>
+                    <name>Elasticsearch node stats indices get missing</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>elasticsearch.node_stats.indices.get.missing_total</key>
+                    <delay>0</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>ES.Indices</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>Elasticsearch node stats indices get missing time</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>elasticsearch.node_stats.indices.get.missing_time_in_millis</key>
+                    <delay>0</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units>ms</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>ES.Indices</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
                     <name>Elasticsearch node stats indices store size</name>
                     <type>2</type>
                     <snmp_community/>


### PR DESCRIPTION
Hi

With this pull request, I implement two useful metrics to keep an eye on unsuccessful GET requests. A GET request retrieves documents based on their ID. An unsuccessful get by ID request means that the document ID was not found.

Two new items :
- Elasticsearch node stats indices get missing
Number of unsuccessful GET requests
- Elasticsearch node stats indices get missing time
Time spent on unsuccessful GET requests